### PR TITLE
Additional include paths for compiling cxplat in the consumer

### DIFF
--- a/src/lib/cxplat.kernel.vcxproj
+++ b/src/lib/cxplat.kernel.vcxproj
@@ -75,7 +75,8 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)inc;$(SolutionDir)\src\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!-- the following paths are for compiling cxplat in the consumer $(SolutionDir)submodules\cxplat\inc;$(SolutionDir)submodules\cxplat\src\inc; -->
+      <AdditionalIncludeDirectories>$(SolutionDir)submodules\cxplat\inc;$(SolutionDir)submodules\cxplat\src\inc;$(SolutionDir)inc;$(SolutionDir)\src\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <AdditionalOptions Condition="'$(Platform)'!='x64'">/Gw /kernel /ZH:SHA_256</AdditionalOptions>

--- a/src/lib/cxplat.kernel.vcxproj
+++ b/src/lib/cxplat.kernel.vcxproj
@@ -75,7 +75,6 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <!-- the following paths are for compiling cxplat in the consumer $(SolutionDir)submodules\cxplat\inc;$(SolutionDir)submodules\cxplat\src\inc; -->
       <AdditionalIncludeDirectories>$(SolutionDir)submodules\cxplat\inc;$(SolutionDir)submodules\cxplat\src\inc;$(SolutionDir)inc;$(SolutionDir)\src\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>

--- a/src/lib/cxplat.user.vcxproj
+++ b/src/lib/cxplat.user.vcxproj
@@ -43,7 +43,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
-  </PropertyGroup>
+  </PropertyGroup>702A7493-A6A4-4209-AB69-E1E4D1EB0FB7
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="PropertySheets">
@@ -72,7 +72,8 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)inc;$(SolutionDir)\src\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!-- the following paths are for compiling cxplat in the consumer $(SolutionDir)submodules\cxplat\inc;$(SolutionDir)submodules\cxplat\src\inc; -->
+      <AdditionalIncludeDirectories>$(SolutionDir)submodules\cxplat\inc;$(SolutionDir)submodules\cxplat\src\inc;$(SolutionDir)inc;$(SolutionDir)\src\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <AdditionalOptions Condition="'$(Platform)'!='x64'">/Gw /kernel /ZH:SHA_256</AdditionalOptions>

--- a/src/lib/cxplat.user.vcxproj
+++ b/src/lib/cxplat.user.vcxproj
@@ -43,7 +43,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
-  </PropertyGroup>702A7493-A6A4-4209-AB69-E1E4D1EB0FB7
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="PropertySheets">
@@ -72,7 +72,6 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <!-- the following paths are for compiling cxplat in the consumer $(SolutionDir)submodules\cxplat\inc;$(SolutionDir)submodules\cxplat\src\inc; -->
       <AdditionalIncludeDirectories>$(SolutionDir)submodules\cxplat\inc;$(SolutionDir)submodules\cxplat\src\inc;$(SolutionDir)inc;$(SolutionDir)\src\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>


### PR DESCRIPTION
When the consumer of cxplat compiles cxplat (via a project reference in the solution file), the environment variables like current working directory, SolutionDir and ProjectDir are relative to the consumer solution. So, it won't be able to locate header files for cxplat anymore using the existing include folder configuration.

This is a little hacky but works? Let me know if you know a better way to do this.