### PR TITLE
Make a CxPlatVector wrapper class for usermode instead of simply using std::vector

### DIFF
--- a/inc/cxplatvector.h
+++ b/inc/cxplatvector.h
@@ -34,5 +34,21 @@ class CxPlatVector : public Rtl::KArray<T>
 #include <vector>
 
 template <typename T>
-using CxPlatVector = std::vector<T>;
+class CxPlatVector : public std::vector<T>
+{
+    public:
+    bool
+    push_back(
+        _In_ T value
+        )
+    {
+        try {
+            std::vector<T>::push_back(value);
+        } catch (...) {
+            return false;
+        }
+        return true;
+    }
+};
+
 #endif

--- a/inc/cxplatvector.h
+++ b/inc/cxplatvector.h
@@ -7,12 +7,12 @@ template <typename T>
 class CxPlatVector : public Rtl::KArray<T>
 {
     public:
-    void
+    bool
     push_back(
         _In_ T value
         )
     {
-        CXPLAT_FRE_ASSERT(append(value));
+        return append(value);
     }
 
     const T* data() const { return &(*this)[0]; }
@@ -26,7 +26,7 @@ class CxPlatVector : public Rtl::KArray<T>
         _In_ const const_iterator &end
         )
     {
-        CXPLAT_FRE_ASSERT(insertAt(dest, start, end));
+        return insertAt(dest, start, end);
     }
 };
 #else

--- a/src/test/lib/VectorTest.cpp
+++ b/src/test/lib/VectorTest.cpp
@@ -16,7 +16,7 @@ void VectorBasic()
     CxPlatVector<uint32_t> Array;
 
     for (uint32_t i = 0; i < 10; i++) {
-        Array.push_back(i);
+        TEST_EQUAL(Array.push_back(i), true);
     }
 
     TEST_EQUAL(Array.size(), 10u);


### PR DESCRIPTION
This wrapper class hides some of the difference between karray and std::vector so that consumers can use CxPlatVector instead of karray directly in both UM and KM.