### PR TITLE
Fix karray fill constructor

### DIFF
--- a/inc/karray.h
+++ b/inc/karray.h
@@ -539,13 +539,14 @@ public:
         PAGED T *operator->() const { return &(*this->_a)[this->_i]; }
     };
 
-    PAGED KArray(size_t sizeHint = 0, const T &value = (T)0) noexcept
+    PAGED KArray(size_t count = 0, const T &value = (T)0) noexcept
     {
-        if (sizeHint)
+        if (count)
         {
-            (void)grow(sizeHint);
-            for (ULONG i = 0; i < m_numElements; i++)
+            (void)grow(count);
+            for (ULONG i = 0; i < count; i++)
                 _p[i] = value;
+            m_numElements = static_cast<ULONG>(count);
         }
     }
 

--- a/src/test/lib/VectorTest.cpp
+++ b/src/test/lib/VectorTest.cpp
@@ -39,6 +39,8 @@ void VectorBasic()
 
     CxPlatVector<uint32_t> ArrayFill(10);
     TEST_EQUAL(ArrayFill.size(), 10u);
+
+    // Verify that the newly appended element will be inserted at 10-th slot.
     ArrayFill.push_back(10);
     TEST_EQUAL(ArrayFill.size(), 11u);
     TEST_EQUAL(ArrayFill[10], 10u);

--- a/src/test/lib/VectorTest.cpp
+++ b/src/test/lib/VectorTest.cpp
@@ -38,4 +38,5 @@ void VectorBasic()
     }
 
     CxPlatVector<uint32_t> ArrayWithSizeHint(10);
+    TEST_EQUAL(ArrayWithSizeHint.size(), 10u);
 }

--- a/src/test/lib/VectorTest.cpp
+++ b/src/test/lib/VectorTest.cpp
@@ -37,6 +37,9 @@ void VectorBasic()
         TEST_EQUAL(Array[i - 1], i);
     }
 
-    CxPlatVector<uint32_t> ArrayWithSizeHint(10);
-    TEST_EQUAL(ArrayWithSizeHint.size(), 10u);
+    CxPlatVector<uint32_t> ArrayFill(10);
+    TEST_EQUAL(ArrayFill.size(), 10u);
+    ArrayFill.push_back(10);
+    TEST_EQUAL(ArrayFill.size(), 11u);
+    TEST_EQUAL(ArrayFill[10], 10u);
 }


### PR DESCRIPTION
The fill constructor is not implemented correctly. It does not really fill the array with specified value as `m_numElements` is zero when it's called.

With the fix, the size passed into fill constructor isn't a hint anymore. Just like std::vector, it will be the number of elements. This will also eliminate the difference of `size()` between karray and std::vector. 