### PR TITLE
Template CxPlatAsync

### DIFF
--- a/inc/cxplat.hpp
+++ b/inc/cxplat.hpp
@@ -22,27 +22,27 @@ Abstract:
 template <typename T, typename R = void>
 class CxPlatAsyncT {
 private:
-    typedef R CxPlatCallback(_Inout_ T* Context);
+    typedef R CallbackT(_Inout_ T* Context);
 
-    struct CxPlatAsyncContext {
+    struct ContextT {
         T* UserContext;
-        CxPlatCallback *UserCallback;
+        CallbackT *UserCallback;
         R ReturnValue;
     };
 
-    static CXPLAT_THREAD_CALLBACK(CxPlatAsyncWrapperCallback, Context) {
-        auto AsyncContext = (CxPlatAsyncContext*)Context;
+    static CXPLAT_THREAD_CALLBACK(ThreadCallback, Context) {
+        auto AsyncContext = (ContextT*)Context;
         AsyncContext->ReturnValue = AsyncContext->UserCallback(AsyncContext->UserContext);
         CXPLAT_THREAD_RETURN(0);
     }
 
-    struct CxPlatAsyncContext AsyncContext {0, 0, 0};
-    CXPLAT_THREAD_CONFIG ThreadConfig {0, 0, "CxPlatAsync", CxPlatAsyncWrapperCallback, &AsyncContext};
+    struct ContextT AsyncContext {0, 0, 0};
+    CXPLAT_THREAD_CONFIG ThreadConfig {0, 0, "CxPlatAsync", ThreadCallback, &AsyncContext};
     CXPLAT_THREAD Thread {0};
     bool ThreadCompleted {false};
     bool Initialized;
 public:
-    CxPlatAsyncT(CxPlatCallback Callback, T* UserContext = nullptr) noexcept
+    CxPlatAsyncT(CallbackT Callback, T* UserContext = nullptr) noexcept
         : AsyncContext({UserContext, Callback, 0}),
           Initialized(CxPlatThreadCreate(&ThreadConfig, &Thread) == 0) {
     }
@@ -79,26 +79,26 @@ public:
 template <typename T>
 class CxPlatAsyncT <T, void>{
 private:
-    typedef void CxPlatCallback(_Inout_ T* Context);
+    typedef void CallbackT(_Inout_ T* Context);
 
-    struct CxPlatAsyncContext {
+    struct ContextT {
         T* UserContext;
-        CxPlatCallback *UserCallback;
+        CallbackT *UserCallback;
     };
 
-    static CXPLAT_THREAD_CALLBACK(CxPlatAsyncWrapperCallback, Context) {
-        auto AsyncContext = (CxPlatAsyncContext*)Context;
+    static CXPLAT_THREAD_CALLBACK(ThreadCallback, Context) {
+        auto AsyncContext = (ContextT*)Context;
         AsyncContext->UserCallback(AsyncContext->UserContext);
         CXPLAT_THREAD_RETURN(0);
     }
 
-    struct CxPlatAsyncContext AsyncContext {0, 0};
-    CXPLAT_THREAD_CONFIG ThreadConfig {0, 0, "CxPlatAsync", CxPlatAsyncWrapperCallback, &AsyncContext};
+    struct ContextT AsyncContext {0, 0};
+    CXPLAT_THREAD_CONFIG ThreadConfig {0, 0, "CxPlatAsync", ThreadCallback, &AsyncContext};
     CXPLAT_THREAD Thread {0};
     bool ThreadCompleted {false};
     bool Initialized;
 public:
-    CxPlatAsyncT(CxPlatCallback Callback, T* UserContext = nullptr) noexcept
+    CxPlatAsyncT(CallbackT Callback, T* UserContext = nullptr) noexcept
         : AsyncContext({UserContext, Callback}),
           Initialized(CxPlatThreadCreate(&ThreadConfig, &Thread) == 0) {
     }
@@ -127,7 +127,5 @@ public:
     }
 #endif
 };
-
-typedef CxPlatAsyncT<void, void*> CxPlatAsync;
 
 #endif

--- a/inc/cxplat.hpp
+++ b/inc/cxplat.hpp
@@ -19,65 +19,8 @@ Abstract:
 #include "cxplat.h"
 #include "cxplat_sal_stub.h"
 
-template <typename T, typename R = void>
-class CxPlatAsyncT {
-private:
-    typedef R CallbackT(_Inout_ T* Context);
-
-    struct ContextT {
-        T* UserContext;
-        CallbackT *UserCallback;
-        R ReturnValue;
-    };
-
-    static CXPLAT_THREAD_CALLBACK(ThreadCallback, Context) {
-        auto AsyncContext = (ContextT*)Context;
-        AsyncContext->ReturnValue = AsyncContext->UserCallback(AsyncContext->UserContext);
-        CXPLAT_THREAD_RETURN(0);
-    }
-
-    struct ContextT AsyncContext {0, 0, 0};
-    CXPLAT_THREAD_CONFIG ThreadConfig {0, 0, "CxPlatAsync", ThreadCallback, &AsyncContext};
-    CXPLAT_THREAD Thread {0};
-    bool ThreadCompleted {false};
-    bool Initialized;
-public:
-    CxPlatAsyncT(CallbackT Callback, T* UserContext = nullptr) noexcept
-        : AsyncContext({UserContext, Callback, 0}),
-          Initialized(CxPlatThreadCreate(&ThreadConfig, &Thread) == 0) {
-    }
-    ~CxPlatAsyncT() noexcept {
-        if (Initialized) {
-            if (!ThreadCompleted) {
-                CxPlatThreadWaitForever(&Thread);
-            }
-            CxPlatThreadDelete(&Thread);
-        }
-    }
-
-    void Wait() noexcept {
-        if (Initialized) {
-            CxPlatThreadWaitForever(&Thread);
-            ThreadCompleted = true;
-        }
-    }
-
-#if defined(CX_PLATFORM_WINUSER) || defined(CX_PLATFORM_WINKERNEL)
-    bool WaitFor(uint32_t TimeoutMs) noexcept {
-        if (Initialized) {
-            return (ThreadCompleted = CxPlatThreadWaitWithTimeout(&Thread, TimeoutMs));
-        }
-        return false;
-    }
-#endif
-
-    R Get() noexcept {
-        return AsyncContext.ReturnValue;
-    }
-};
-
 template <typename T>
-class CxPlatAsyncT <T, void>{
+class CxPlatAsyncT {
 private:
     typedef void CallbackT(_Inout_ T* Context);
 
@@ -127,5 +70,7 @@ public:
     }
 #endif
 };
+
+typedef CxPlatAsyncT<void> CxPlatAsync;
 
 #endif

--- a/src/test/lib/ThreadTest.cpp
+++ b/src/test/lib/ThreadTest.cpp
@@ -64,7 +64,7 @@ Failure:
 void CxPlatTestThreadAsync()
 {
     {
-        CxPlatAsync Async([](void*) -> void* {
+        CxPlatAsyncT<void,void*> Async([](void*) -> void* {
             return nullptr;
         });
     }
@@ -100,15 +100,15 @@ void CxPlatTestThreadAsync()
 
 #if defined(CX_PLATFORM_WINUSER) || defined(CX_PLATFORM_WINKERNEL)
     {
-        CxPlatAsync Async([](void*) -> void* {
+        CxPlatAsyncT<void,intptr_t> Async([](void*) -> intptr_t {
             CxPlatSleep(2000);
-            return (void*)(intptr_t)(0xdeadbeaf);
+            return (intptr_t)(0xdeadbeaf);
         });
 
         TEST_FALSE(Async.WaitFor(50));
-        TEST_EQUAL(Async.Get(), nullptr);
+        TEST_EQUAL(Async.Get(), 0);
         Async.Wait();
-        TEST_NOT_EQUAL(Async.Get(), nullptr);
+        TEST_NOT_EQUAL(Async.Get(), 0);
     }
 #endif
 }

--- a/src/test/lib/ThreadTest.cpp
+++ b/src/test/lib/ThreadTest.cpp
@@ -72,33 +72,31 @@ void CxPlatTestThreadAsync()
     {
         struct TempCtx {
             uint32_t Value;
-        } TempCtx = { 0 };
-        CxPlatAsync Async([](void* Ctx) -> void* {
-            struct TempCtx* TempCtx = (struct TempCtx*)Ctx;
-            TempCtx->Value = 123;
+        } Ctx = { 0 };
+        CxPlatAsyncT<TempCtx,void*> Async([](TempCtx* Ctx) -> void* {
+            Ctx->Value = 123;
             return nullptr;
-        }, &TempCtx);
+        }, &Ctx);
         Async.Wait();
-        TEST_EQUAL(123, TempCtx.Value);
-    }   
+        TEST_EQUAL(123, Ctx.Value);
+    }
 
     {
         CXPLAT_THREAD_ID ThreadId = INITIAL_THREAD_ID_VALUE;
-        CxPlatAsync Async([](void* Ctx) -> void* {
-            CXPLAT_THREAD_ID* ThreadId = (CXPLAT_THREAD_ID*)Ctx;
-            *ThreadId = CxPlatCurThreadID();
-            return (void*)(intptr_t)(*ThreadId);
+        CxPlatAsyncT<CXPLAT_THREAD_ID,CXPLAT_THREAD_ID> Async([](CXPLAT_THREAD_ID* Ctx) -> CXPLAT_THREAD_ID {
+            *Ctx = CxPlatCurThreadID();
+            return *Ctx;
         }, &ThreadId);
 
         Async.Wait();
-        TEST_EQUAL((CXPLAT_THREAD_ID)((intptr_t)Async.Get()), ThreadId);
+        TEST_EQUAL(Async.Get(), ThreadId);
         TEST_NOT_EQUAL(INITIAL_THREAD_ID_VALUE, ThreadId);
     }
 
 #if defined(CX_PLATFORM_WINUSER) || defined(CX_PLATFORM_WINKERNEL)
     {
         CxPlatAsync Async([](void*) -> void* {
-            CxPlatSleep(2000);   
+            CxPlatSleep(2000);
             return (void*)(intptr_t)(0xdeadbeaf);
         });
 

--- a/src/test/lib/ThreadTest.cpp
+++ b/src/test/lib/ThreadTest.cpp
@@ -70,12 +70,17 @@ void CxPlatTestThreadAsync()
     }
 
     {
+        CxPlatAsyncT<void> Async([](void*) -> void {
+            // no-op
+        });
+    }
+
+    {
         struct TempCtx {
             uint32_t Value;
         } Ctx = { 0 };
-        CxPlatAsyncT<TempCtx,void*> Async([](TempCtx* Ctx) -> void* {
+        CxPlatAsyncT<TempCtx> Async([](TempCtx* Ctx) -> void {
             Ctx->Value = 123;
-            return nullptr;
         }, &Ctx);
         Async.Wait();
         TEST_EQUAL(123, Ctx.Value);


### PR DESCRIPTION
Updates CxPlatAsync interface so that the input type is templated and removes the return type so that callers can remove all the extra casting as well as we provide compile-time type safety. The downside is that you must explicitly specify the template types (though you can always define your own typedef). Example usages (from test code):

```c++
CxPlatAsync Async([](void*) -> void {
    // no-op
});
```

```c++
uint32_t Ctx = 0;
CxPlatAsyncT<uint32_t> Async([](uint32_t* Ctx) -> void {
    *Ctx = 123;
}, &Ctx);
```